### PR TITLE
Bump WWW::Pastebin::PastebinCom::Create version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -36,7 +36,7 @@ LWP::Protocol = 0
 -description = pastebin.com support
 -always_recommend = 1
 -default = 0
-WWW::Pastebin::PastebinCom::Create = 0
+WWW::Pastebin::PastebinCom::Create = 1.003
 
 [OptionalFeature / Clipboard]
 -description = copying of URLs with -x/--copy


### PR DESCRIPTION
Not sure whether you want to apply this, but versions of `WWW::Pastebin::PastebinCom::Create` below 1.003 have bugs and below 1.001 are broken entirely (completely defunct).

Having 0 as version won't update the module, if the person already has the old, broken version installed.
