### PR TITLE
Enables a passing Test::UnusedVars test

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,7 +15,6 @@ Test::MinimumVersion.max_target_perl = 5.008003
 -remove = PodCoverageTests      ; TODO
 -remove = Test::PodSpelling     ; TODO
 -remove = Test::Pod::No404s     ; TODO
--remove = Test::UnusedVars      ; TODO
 
 [ContributorsFromGit]
 

--- a/lib/App/Nopaste/Service/ssh.pm
+++ b/lib/App/Nopaste/Service/ssh.pm
@@ -27,7 +27,7 @@ sub run {
     my $suffix = $ext;
     if ($usedesc) {
         if (not $args{'desc'}) {
-            my ($vol, $dirs, $file) = File::Spec->splitpath($source);
+            my $file = ( File::Spec->splitpath($source) )[2];
             $args{'desc'} = $file || '';
         }
         $args{'desc'} =~ s/\s+/+/g; # more readable than %20
@@ -52,7 +52,7 @@ sub run {
 
     system('scp', '-pq', $filename, "$server:$docroot");
 
-    my ($volume, $dir, $file) = File::Spec->splitpath($filename);
+    my $file = ( File::Spec->splitpath($filename) )[2];
     $file = uri_escape($file);
     $file =~ s/%2b/+/gi;
 


### PR DESCRIPTION
I also tried fixing the No404s test, but not only some paste sites seem to be dead now, but there's an example URL in code sample in the Gist.pm that Test::Pod::No404s tries to follow like an idiot :/
