### PR TITLE
Strictify JSON boolean and content-type in Gist post

### DIFF
--- a/lib/App/Nopaste/Service/Gist.pm
+++ b/lib/App/Nopaste/Service/Gist.pm
@@ -22,7 +22,7 @@ sub run {
     my $ua = LWP::UserAgent->new;
 
     my $content = {
-        public => defined $arg{private} ? 0 : 1,
+        public => defined $arg{private} ? JSON->false : JSON->true,
         defined $arg{desc} ? (description => $arg{desc}) : (),
     };
 
@@ -47,7 +47,8 @@ sub run {
             $ua->post(
                 $url,
                 'Authorization' => "token $auth{oauth_token}",
-                Content         => $content
+                Content         => $content,
+                Content_Type    => 'application/json',
             );
         }
         else {


### PR DESCRIPTION
This fixes the 422 Unprocessible Entity with the Gist service:

```
Invalid request.\n\nNo subschema in \"anyOf\" matched.
```