### PR TITLE
Do not need `stringify` on `basename` return value

### DIFF
--- a/lib/App/Nopaste/Service/Gist.pm
+++ b/lib/App/Nopaste/Service/Gist.pm
@@ -30,7 +30,7 @@ sub run {
     };
 
     my $filename = defined $arg{filename}
-                 ? path($arg{filename})->basename->stringify
+                 ? path($arg{filename})->basename
                  : 'nopaste';
 
     $content->{files} = {


### PR DESCRIPTION
`Path::Tiny::basename` returns a string, so calling `stringify`
does not work.