### PR TITLE
Make Service::Mojopaste work again

### DIFF
--- a/lib/App/Nopaste/Service/Mojopaste.pm
+++ b/lib/App/Nopaste/Service/Mojopaste.pm
@@ -24,8 +24,8 @@ sub fill_form {
 
     $mech->submit_form(
         fields        => {
-            p       => 1,
-            content => $args{text},
+            p     => 1,
+            paste => $args{text},
         },
     );
 


### PR DESCRIPTION
Current versions of mojopaste have the field named "paste", not "content".

It would probably be possible to use Mech to discover the field name and support either, but the thorsen.pm one uses "paste", and anyone setting it up new will have "paste", so this is simpler.