### PR TITLE
Correct NAME section of script pod

### DIFF
--- a/script/nopaste
+++ b/script/nopaste
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-# PODNAME: command-line utility to nopaste
+# PODNAME: nopaste - command-line utility to nopaste
 
 use App::Nopaste::Command;
 


### PR DESCRIPTION
the NAME section has a specific format which metacpan uses to index the script's pod.